### PR TITLE
Close URLClassLoader instances created by LibraryClassLoader on shutdown

### DIFF
--- a/rdm-common/src/main/java/redisfx/tanh/rdm/common/util/LibraryClassLoader.java
+++ b/rdm-common/src/main/java/redisfx/tanh/rdm/common/util/LibraryClassLoader.java
@@ -12,7 +12,7 @@ import java.util.List;
 /**
  * 自定义类加载器，用于加载 libs 目录下的 JAR 文件
  */
-public class LibraryClassLoader extends ClassLoader {
+public class LibraryClassLoader extends ClassLoader implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(LibraryClassLoader.class);
     private  File libDirectory;
     private final List<URLClassLoader> jarLoaders = new ArrayList<>();
@@ -52,7 +52,6 @@ public class LibraryClassLoader extends ClassLoader {
     }
 
     public void initializeJarLoaders() {
-        jarLoaders.clear();
         if (libDirectory.exists() && libDirectory.isDirectory()) {
             File[] jarFiles = libDirectory.listFiles((dir, name) -> name.endsWith(".jar"));
             if (jarFiles != null) {
@@ -70,5 +69,25 @@ public class LibraryClassLoader extends ClassLoader {
             }
             log.info("Loaded {} JARs from {}", jarLoaders.size(), libDirectory.getAbsolutePath());
         }
+    }
+
+    @Override
+    public void close() {
+        Exception first = null;
+        for (URLClassLoader cl : jarLoaders) {
+            try {
+                cl.close();
+            } catch (Exception e) {
+                if (first == null) {
+                    first = e;
+                } else {
+                    first.addSuppressed(e);
+                }
+            }
+        }
+        if (first != null) {
+            log.warn("Failed to close one or more JAR classloaders", first);
+        }
+        jarLoaders.clear();
     }
 }

--- a/rdm-ui/src/main/java/redisfx/tanh/rdm/ui/Main.java
+++ b/rdm-ui/src/main/java/redisfx/tanh/rdm/ui/Main.java
@@ -253,6 +253,18 @@ public class Main extends Application {
         getHostServices().showDocument(event.getUri().toString());
     }
 
+    @Override
+    public void stop() throws Exception {
+        try {
+            ClassLoader customLoader = Thread.currentThread().getContextClassLoader();
+            if (customLoader instanceof LibraryClassLoader) {
+                ((LibraryClassLoader) customLoader).close();
+            }
+        } finally {
+            super.stop();
+        }
+    }
+
     public MainController getController() {
         return controller;
     }


### PR DESCRIPTION
### Description

`LibraryClassLoader` loads JARs from ./libs by creating `URLClassLoader` instances, but there was no cleanup path to close those loaders. `URLClassLoader` can retain open JAR file handles, which may keep JARs locked on some platforms.

### Changes

- Make `LibraryClassLoader` implement `AutoCloseable` and close all created `URLClassLoaders` in close() (best-effort, with suppressed exceptions), then clear the loaders.
- Close the active `LibraryClassLoader` from `Main.stop()` using the thread context class loader.